### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'matplotlib',
     'numpy',
     'tqdm',
-    'sklearn',
+    'scikit-learn',  #sklearn has been deprecated 
     'scipy',
     'toolz',
     'bayesian-optimization >= 1.1.0'


### PR DESCRIPTION
The line `'sklearn'` in `setup.py` produces an error when installing from pip. Command:
` pip install git+https://github.com/MasaAsami/pysynthdid`

produced
```× python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)```